### PR TITLE
Remove vagrant box add step

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Requirements: this is meant to run on almost any system. However, you will need 
 5. 
     * (Mac, Optional) Just to make sure you're in the right place, type `ls`. You should see the names of a number of files, one of which is called "Vagrantfile". If don't but you see a file called "medicalHeritageVM," you're one level too high: go back to step 4 and drag from **inside** the unzipped folder, **not** the folder that contains the zipfile.![Your terminal should look something like this](docs/cd_output.png)
     * (Windows) Double check that you're in the right place.
-6. Enter the command: `vagrant box add ubuntu/wily64` and press Return.
-7. Enter the command: `vagrant up` and press Return.
-8. Go to bed, or out for a leisurely dinner, or something. Now begins a long process of downloading and installing software. This will require a large amount of disk space and time to complete. You will know it is finished when you get a new command prompt (and hopefully no error messages). There *will* be a large number of messages printed to your screen in any case. Just ignore them.
-9. Make sure you have the necessary files. In that same unzipped folder, there should be two folders, one called "texts" and one called "images". Open each of them, and make sure that
+6. Enter the command: `vagrant up` and press Return.
+7. Go to bed, or out for a leisurely dinner, or something. Now begins a long process of downloading and installing software. This will require a large amount of disk space and time to complete. You will know it is finished when you get a new command prompt (and hopefully no error messages). There *will* be a large number of messages printed to your screen in any case. Just ignore them.
+8. Make sure you have the necessary files. In that same unzipped folder, there should be two folders, one called "texts" and one called "images". Open each of them, and make sure that
       a.) There's a folder in "images" called "jpeg" that has a bunch of journal pages in it
       b.) There's a folder in "texts" called sample_data that has two folders with the full runs of a few medical journals.
 


### PR DESCRIPTION
Just verified -- `vagrant up` isn't required when using a modern Vagrant:

``` sh
➜  medicalHeritageVM git:(master) vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'ubuntu/wily64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Loading metadata for box 'ubuntu/wily64'
    default: URL: https://atlas.hashicorp.com/ubuntu/wily64
==> default: Adding box 'ubuntu/wily64' (v20160319.0.0) for provider: virtualbox
    default: Downloading: https://atlas.hashicorp.com/ubuntu/boxes/wily64/versions/20160319.0.0/providers/virtualbox.box
    default: Progress: 0% (Rate: 495k/s, Estimated time remaining: 0:22:22)
```
